### PR TITLE
ADD methods for ACLs

### DIFF
--- a/nexussdk/acls.py
+++ b/nexussdk/acls.py
@@ -1,0 +1,78 @@
+import json
+from typing import Any, Dict, Optional
+
+from utils.http import (http_delete, http_get, http_patch, http_put)
+
+JSON = Dict[str, Any]
+
+
+def output(with_pretty_print=True):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            response = func(*args, **kwargs)
+            if with_pretty_print:
+                print("{} {}".format(response.request.method, response.url))
+                print(json.dumps(response.json(), indent=2))
+            if not with_pretty_print:
+                return response.json()
+        return wrapper
+    return decorator
+
+
+# Create functions.
+
+@output()
+def create(path: str, acls: JSON) -> JSON:
+    # PUT /v1/acls/{subpath}
+    return http_put(path, acls, use_base=False)
+
+
+# Read functions.
+
+@output()
+def fetch(path: str, rev: Optional[int] = None, self: bool = True) -> JSON:
+    # GET /v1/acls/{subpath}?rev={rev}&self={self}
+    if rev is None:
+        url = "{}?self={}".format(path, self)
+    else:
+        url = "{}?rev={}&self={}".format(path, rev, self)
+    return http_get(url, use_base=False)
+
+
+@output()
+def list_(path: str, ancestors: bool = False, self: bool = True) -> JSON:
+    # GET /v1/acls/{subpath}?ancestors={ancestors}&self={self}
+    url = "{}?ancestors={}&self={}".format(path, ancestors, self)
+    return http_get(url, use_base=False)
+
+
+# Update functions.
+
+@output()
+def replace(path: str, rev: int, acls: JSON) -> JSON:
+    # PUT /v1/acls/{subpath}?rev={rev}
+    url = "{}?rev={}".format(path, rev)
+    return http_put(url, acls, use_base=False)
+
+
+@output()
+def append(path: str, rev: int, acls: JSON) -> JSON:
+    # PATCH /v1/acls/{subpath}?rev={rev}
+    url = "{}?rev={}".format(path, rev)
+    return http_patch(url, acls, use_base=False)
+
+
+@output()
+def subtract(path: str, rev: int, acls: JSON) -> JSON:
+    # PATCH /v1/acls/{subpath}?rev={rev}
+    url = "{}?rev={}".format(path, rev)
+    return http_patch(url, acls, use_base=False)
+
+
+# Delete functions.
+
+@output()
+def delete(path: str, rev: int) -> JSON:
+    # DELETE /v1/acls/{subpath}?rev={rev}
+    url = "{}?rev={}".format(path, rev)
+    return http_delete(url, use_base=False)

--- a/nexussdk/utils/http.py
+++ b/nexussdk/utils/http.py
@@ -73,6 +73,14 @@ def http_put(url, body=None, data_type='default', use_base = True):
     return response
 
 
+def http_patch(url, body=None, data_type='default', use_base=True):
+    header = prepare_header()
+    full_url = (storage.get('environment') if use_base else '') + url
+    body_data = prepare_body(body, data_type)
+    response = requests.patch(full_url, headers=header, data=body_data)
+    return response
+
+
 def http_delete(url, body=None, data_type='default', use_base = True):
     header = prepare_header()
     full_url = (storage.get('environment') if use_base else '') + url


### PR DESCRIPTION
Add acls.py with all the methods from the doc.

Add `http_path(...)` as a copy-pasting of `http_put(...)` for now.

Add an advanced decorator to factorize code. Now it focuses only on adding nice debugging features but I expect it to handle the repeated code in the `http_xxx(...)` methods and their output in the future.