### PR TITLE
http and resource

### DIFF
--- a/nexussdk/config.py
+++ b/nexussdk/config.py
@@ -1,5 +1,6 @@
 from . utils.store import storage
 
+
 def set_token(token):
     storage.set("token", token)
 

--- a/nexussdk/organization.py
+++ b/nexussdk/organization.py
@@ -1,11 +1,7 @@
-import json
 from . utils.http import http_get
-from . utils.http import is_response_valid
 from . utils.http import http_put
 from . utils.http import http_delete
-import urllib.parse
-
-url_encode = urllib.parse.quote_plus
+from urllib.parse import quote_plus as url_encode
 
 
 def fetch(org_label, rev=None):
@@ -22,15 +18,7 @@ def fetch(org_label, rev=None):
     if rev is not None:
         path = path + "?rev=" + str(rev)
 
-    response_raw = http_get(path)
-
-    if not is_response_valid(response_raw):
-        raise Exception("Invalid http request for " + response_raw.url +
-                        " (Status " + str(response_raw.status_code) + ")" + "\n" +
-                        response_raw.text)
-
-    response_obj = json.loads(response_raw.text)
-    return response_obj
+    return http_get(path)
 
 
 def create(org_label, name=None, description=None):
@@ -59,16 +47,7 @@ def create(org_label, name=None, description=None):
     else:
         data["description"] = ""
 
-    response_raw = http_put(path, body=data)
-
-
-    if not is_response_valid(response_raw):
-        raise Exception("Invalid http request for " + response_raw.url +
-                        " (Status " + str(response_raw.status_code) + ")" + "\n" +
-                        response_raw.text)
-
-    response_obj = json.loads(response_raw.text)
-    return response_obj
+    return http_put(path, body=data)
 
 
 def update(org, previous_rev=None):
@@ -87,14 +66,7 @@ def update(org, previous_rev=None):
 
     path = "/orgs/" + org_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_put(path, org)
-
-    raise Exception("Invalid http request for " + response_raw.url +
-                    " (Status " + str(response_raw.status_code) + ")" + "\n" +
-                    response_raw.text)
-
-    response_obj = json.loads(response_raw.text)
-    return response_obj
+    return http_put(path, org)
 
 
 def list(pagination_from=0, pagination_size=20, deprecated=None, full_text_search_query=None):
@@ -121,15 +93,7 @@ def list(pagination_from=0, pagination_size=20, deprecated=None, full_text_searc
         full_text_search_query = url_encode(full_text_search_query)
         path = path + "&q=" + full_text_search_query
 
-    response_raw = http_get(path)
-
-    if not is_response_valid(response_raw):
-        raise Exception("Invalid http request for " + response_raw.url +
-                        " (Status " + str(response_raw.status_code) + ")" + "\n" +
-                        response_raw.text)
-
-    response_obj = json.loads(response_raw.text)
-    return response_obj
+    return http_get(path)
 
 
 def deprecate(org_label, previous_rev):
@@ -146,15 +110,7 @@ def deprecate(org_label, previous_rev):
     org_label = url_encode(org_label)
     path = "/orgs/" + org_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_delete(path)
-
-    if not is_response_valid(response_raw):
-        raise Exception("Invalid http request for " + response_raw.url +
-                        " (Status " + str(response_raw.status_code) + ")" + "\n" +
-                        response_raw.text)
-
-    response_obj = json.loads(response_raw.text)
-    return response_obj
+    return http_delete(path)
 
 
 

--- a/nexussdk/organization.py
+++ b/nexussdk/organization.py
@@ -15,12 +15,12 @@ def fetch(org_label, rev=None):
     :return: All the details of this organization, as a dictionary
     """
     org_label = urllib.parse.quote_plus(org_label)
-    url = "/orgs/" + org_label
+    path = "/orgs/" + org_label
 
     if rev is not None:
-        url = url + "?rev=" + str(rev)
+        path = path + "?rev=" + str(rev)
 
-    response_raw = http_get(url)
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -41,7 +41,7 @@ def create(org_label, name=None, description=None):
     :return: The payload from the Nexus API as a dictionary. This contains the Nexus metadata of the organization
     """
     org_label = urllib.parse.quote_plus(org_label)
-    url = "/orgs/" + org_label
+    path = "/orgs/" + org_label
 
     data = {}
 
@@ -57,7 +57,7 @@ def create(org_label, name=None, description=None):
     else:
         data["description"] = ""
 
-    response_raw = http_put(url, body=data)
+    response_raw = http_put(path, body=data)
 
 
     if not is_response_valid(response_raw):
@@ -83,9 +83,9 @@ def update(org, previous_rev=None):
     if previous_rev is None:
         previous_rev = org["_rev"]
 
-    url = "/orgs/" + org_label + "?rev=" + str(previous_rev)
+    path = "/orgs/" + org_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_put(url, org)
+    response_raw = http_put(path, org)
 
     raise Exception("Invalid http request for " + response_raw.url +
                     " (Status " + str(response_raw.status_code) + ")" + "\n" +
@@ -109,17 +109,17 @@ def list(pagination_from=0, pagination_size=20, deprecated=None, full_text_searc
     :return: The payload from the Nexus API as a dictionary. This contains the Nexus metadata of the organization
     """
 
-    url = "/orgs?from=" + str(pagination_from) + "&size=" + str(pagination_size)
+    path = "/orgs?from=" + str(pagination_from) + "&size=" + str(pagination_size)
 
     if deprecated is not None:
         deprecated = "true" if deprecated else "false"
-        url = url + "&deprecated=" + deprecated
+        path = path + "&deprecated=" + deprecated
 
     if full_text_search_query is not None:
         full_text_search_query = urllib.parse.quote_plus(full_text_search_query)
-        url = url + "&q=" + full_text_search_query
+        path = path + "&q=" + full_text_search_query
 
-    response_raw = http_get(url)
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -142,9 +142,9 @@ def deprecate(org_label, previous_rev):
     :return: The payload from the Nexus API as a dictionary. This contains the Nexus metadata of the organization
     """
     org_label = urllib.parse.quote_plus(org_label)
-    url = "/orgs/" + org_label + "?rev=" + str(previous_rev)
+    path = "/orgs/" + org_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_delete(url)
+    response_raw = http_delete(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +

--- a/nexussdk/project.py
+++ b/nexussdk/project.py
@@ -19,12 +19,12 @@ def fetch(org_label, project_label, rev=None):
 
     org_label = urllib.parse.quote_plus(org_label)
     project_label = urllib.parse.quote_plus(project_label)
-    url = "/projects/" + org_label + "/" + project_label
+    path = "/projects/" + org_label + "/" + project_label
 
     if rev is not None:
-        url = url + "?rev=" + str(rev)
+        path = path + "?rev=" + str(rev)
 
-    response_raw = http_get(url)
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -47,12 +47,12 @@ def create(org_label, project_label, config=None):
     """
     org_label = urllib.parse.quote_plus(org_label)
     project_label = urllib.parse.quote_plus(project_label)
-    url = "/projects/" + org_label + "/" + project_label
+    path = "/projects/" + org_label + "/" + project_label
 
     if config is None:
         config = {}
 
-    response_raw = http_put(url, body=config)
+    response_raw = http_put(path, body=config)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -81,9 +81,9 @@ def update(project, previous_rev=None):
     org_label = urllib.parse.quote_plus(project["_organizationLabel"])
     project_label = urllib.parse.quote_plus(project["_label"])
 
-    url = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
+    path = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_put(url, project)
+    response_raw = http_put(path, project)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -109,23 +109,23 @@ def list(org_label=None, pagination_from=0, pagination_size=20, deprecated=None,
     :return: The payload from the Nexus API as a dictionary. This contains the Nexus metadata and the list of projects
     """
 
-    url = "/projects"
+    path = "/projects"
 
     if org_label is not None:
         org_label = urllib.parse.quote_plus(org_label)
-        url = url + "/" + org_label
+        path = path + "/" + org_label
 
-    url = url + "?from=" + str(pagination_from) + "&size=" + str(pagination_size)
+    path = path + "?from=" + str(pagination_from) + "&size=" + str(pagination_size)
 
     if deprecated is not None:
         deprecated = "true" if deprecated else "false"
-        url = url + "&deprecated=" + deprecated
+        path = path + "&deprecated=" + deprecated
 
     if full_text_search_query is not None:
         full_text_search_query = urllib.parse.quote_plus(full_text_search_query)
-        url = url + "&q=" + full_text_search_query
+        path = path + "&q=" + full_text_search_query
 
-    response_raw = http_get(url)
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -152,9 +152,9 @@ def deprecate(org_label, project_label, previous_rev):
     org_label = urllib.parse.quote_plus(org_label)
     project_label = urllib.parse.quote_plus(project_label)
 
-    url = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
+    path = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_delete(url)
+    response_raw = http_delete(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +

--- a/nexussdk/project.py
+++ b/nexussdk/project.py
@@ -1,11 +1,7 @@
-import json
 from . utils.http import http_get
-from . utils.http import is_response_valid
 from . utils.http import http_put
 from . utils.http import http_delete
-import urllib.parse
-
-url_encode = urllib.parse.quote_plus
+from urllib.parse import quote_plus as url_encode
 
 
 def fetch(org_label, project_label, rev=None):
@@ -26,8 +22,7 @@ def fetch(org_label, project_label, rev=None):
     if rev is not None:
         path = path + "?rev=" + str(rev)
 
-    response_raw = http_get(path)
-    return json.loads(response_raw.text)
+    return http_get(path)
 
 
 def create(org_label, project_label, config=None):
@@ -48,8 +43,7 @@ def create(org_label, project_label, config=None):
     if config is None:
         config = {}
 
-    response_raw = http_put(path, body=config)
-    return json.loads(response_raw.text)
+    return http_put(path, body=config)
 
 
 def update(project, previous_rev=None):
@@ -72,8 +66,7 @@ def update(project, previous_rev=None):
 
     path = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_put(path, project)
-    return json.loads(response_raw.text)
+    return http_put(path, project)
 
 
 def list(org_label=None, pagination_from=0, pagination_size=20, deprecated=None, full_text_search_query=None):
@@ -107,8 +100,7 @@ def list(org_label=None, pagination_from=0, pagination_size=20, deprecated=None,
         full_text_search_query = url_encode(full_text_search_query)
         path = path + "&q=" + full_text_search_query
 
-    response_raw = http_get(path)
-    return json.loads(response_raw.text)
+    return http_get(path)
 
 
 def deprecate(org_label, project_label, previous_rev):
@@ -129,6 +121,5 @@ def deprecate(org_label, project_label, previous_rev):
 
     path = "/projects/" + org_label + "/" + project_label + "?rev=" + str(previous_rev)
 
-    response_raw = http_delete(path)
-    return json.loads(response_raw.text)
+    return http_delete(path)
 

--- a/nexussdk/resource.py
+++ b/nexussdk/resource.py
@@ -33,8 +33,8 @@ def fetch(org_label, project_label, schema_id, resource_id):
     schema_id = urllib.parse.quote_plus(schema_id)
     resource_id = urllib.parse.quote_plus(resource_id)
 
-    url = "/resources/" + org_label + "/" + project_label + "/" + schema_id + "/" + resource_id
-    response_raw = http_get(url)
+    path = "/resources/" + org_label + "/" + project_label + "/" + schema_id + "/" + resource_id
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -61,9 +61,9 @@ def update(resource, previous_rev=None):
     if previous_rev is None:
         previous_rev = resource["_rev"]
 
-    url = resource["_self"] + "?rev=" + str(previous_rev)
+    path = resource["_self"] + "?rev=" + str(previous_rev)
 
-    response_raw = http_put(url, resource, use_base=False)
+    response_raw = http_put(path, resource, use_base=False)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -98,13 +98,13 @@ def create(org_label, project_label, data, schema_id='resource', resource_id=Non
     project_label = urllib.parse.quote_plus(project_label)
     schema_id = urllib.parse.quote_plus(schema_id)
 
-    url = "/resources/" + org_label + "/" + project_label + "/" + schema_id
+    path = "/resources/" + org_label + "/" + project_label + "/" + schema_id
 
     # If the data does not have a '@context' field, we should had a default one
     if "@context" not in data:
         copy_this_into_that(DEFAULT_CONTEXT, data)
 
-    response_raw = http_post(url, data)
+    response_raw = http_post(path, data)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -134,23 +134,23 @@ def list(org_label, project_label, schema=None, pagination_from=0, pagination_si
     org_label = urllib.parse.quote_plus(org_label)
     project_label = urllib.parse.quote_plus(project_label)
 
-    url = "/resources/" + org_label + "/" + project_label
+    path = "/resources/" + org_label + "/" + project_label
 
     if schema:
         schema = urllib.parse.quote_plus(schema)
-        url = url + "/" + schema
+        path = path + "/" + schema
 
-    url = url + "?from=" + str(pagination_from) + "&size=" + str(pagination_size)
+    path = path + "?from=" + str(pagination_from) + "&size=" + str(pagination_size)
 
     if deprecated is not None:
         deprecated = "true" if deprecated else "false"
-        url = url + "&deprecated=" + deprecated
+        path = path + "&deprecated=" + deprecated
 
     if full_text_search_query:
         full_text_search_query = urllib.parse.quote_plus(full_text_search_query)
-        url = url + "&q=" + full_text_search_query
+        path = path + "&q=" + full_text_search_query
 
-    response_raw = http_get(url)
+    response_raw = http_get(path)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +
@@ -175,9 +175,9 @@ def deprecate(resource, previous_rev=None):
     if previous_rev is None:
         previous_rev = resource["_rev"]
 
-    url = resource["_self"] + "?rev=" + str(previous_rev)
+    path = resource["_self"] + "?rev=" + str(previous_rev)
 
-    response_raw = http_delete(url, use_base=False)
+    response_raw = http_delete(path, use_base=False)
 
     if not is_response_valid(response_raw):
         raise Exception("Invalid http request for " + response_raw.url +

--- a/nexussdk/utils/http.py
+++ b/nexussdk/utils/http.py
@@ -66,12 +66,16 @@ def print_request_response(r):
     print('history: ', r.history)
 
 
-def http_get(path, use_base = True):
+def http_get(path, use_base = True, get_raw_response=False, stream=False):
     header = prepare_header()
     full_url = (storage.get('environment') if use_base else '') + path
-    response = requests.get(full_url, headers=header)
+    response = requests.get(full_url, headers=header, stream=stream)
     response.raise_for_status()
-    return json.loads(response.text)
+
+    if get_raw_response:
+        return response
+    else:
+        return json.loads(response.text)
 
 
 def http_post(path, body=None, data_type='default'):
@@ -102,7 +106,6 @@ def http_put(path, body=None, data_type='default', use_base = True):
         body_data = prepare_body(body, data_type)
         response = requests.put(full_url, headers=header, data=body_data)
     else:
-
         response = requests.put(full_url, headers=header, files=body)
 
     response.raise_for_status()

--- a/nexussdk/utils/http.py
+++ b/nexussdk/utils/http.py
@@ -14,7 +14,10 @@ header_parts['default'] = header_parts[default_type]
 
 def prepare_header(type='default'):
     """
-    type: string. Must be one of the keys in the above declared dict header_parts
+        Prepare the header of the HTTP request by fetching the token from the config
+        and few other things.
+
+        :param type: string. Must be one of the keys in the above declared dict header_parts
     """
     header = {**header_parts['common'], **header_parts[type]}
     if storage.has('token'):
@@ -23,6 +26,12 @@ def prepare_header(type='default'):
 
 
 def prepare_body(data, type='default'):
+    """
+        Prepare the body of the HTTP request
+    :param data:
+    :param type:
+    :return:
+    """
     if type == 'default':
         type = default_type
     body = None
@@ -50,36 +59,36 @@ def print_request_response(r):
     print('history: ', r.history)
 
 
-def http_get(url, use_base = True):
+def http_get(path, use_base = True):
     header = prepare_header()
-    full_url = (storage.get('environment') if use_base else '') + url
+    full_url = (storage.get('environment') if use_base else '') + path
     response = requests.get(full_url, headers=header)
     return response
 
 
-def http_post(url, body=None, data_type='default'):
+def http_post(path, body=None, data_type='default'):
     header = prepare_header(data_type)
-    full_url = storage.get('environment') + url
+    full_url = storage.get('environment') + path
     body_data = prepare_body(body, data_type)
     response = requests.post(full_url, headers=header, data=body_data)
     return response
 
 
-def http_put(url, body=None, data_type='default', use_base = True):
+def http_put(path, body=None, data_type='default', use_base = True):
     header = prepare_header()
-    full_url = (storage.get('environment') if use_base else '') + url
+    full_url = (storage.get('environment') if use_base else '') + path
     body_data = prepare_body(body, data_type)
     response = requests.put(full_url, headers=header, data=body_data)
     return response
 
 
-def http_delete(url, body=None, data_type='default', use_base = True):
+def http_delete(path, body=None, data_type='default', use_base = True):
     header = prepare_header()
-    full_url = (storage.get('environment') if use_base else '') + url
+    full_url = (storage.get('environment') if use_base else '') + path
     body_data = prepare_body(body, data_type)
     response = requests.delete(full_url, headers=header, data=body_data)
     return response
 
 
 def is_response_valid(response):
-    return (response.status_code < 300)
+    return response.status_code < 300


### PR DESCRIPTION
This PR contains modifications on the http package:
- The returned value of the functions is no longer the object returned by `request.get/put/etc.` but the dictionary equivalent of the JSON response
- Exceptions in case of bad status (above 300) is now thrown directly by the http package methods and do not have to be dealt with externally
- The `http_get` function is now able to stream its result (disabled by default), this is convenient when downloading a file
- The `http_put` function can now send a file using native features of request (disabled by default)
- adding doc string

The resource package now comes with the capability to attach files. Unfortunatelly, this feature will be soon deprecated as `/files/` will be an endpoint and first class citizen.
