### PR TITLE
Sync IAM Realms and ACLs signatures with latest Nexus expected payloads

### DIFF
--- a/nexussdk/acls.py
+++ b/nexussdk/acls.py
@@ -13,8 +13,8 @@ def fetch(subpath: str, rev: int = None, self: bool = True) -> Dict:
     :param subpath: Subpath on which fetching the ACLs.
     :param rev: (optional) Revision number of the ACLs.
     :param self: (optional) If 'True', only the ACLs containing the identities
-    found in the authentication token are returned. If 'False', all the ACLs
-    on the current subpath are returned.
+        found in the authentication token are returned. If 'False', all the
+        ACLs on the current subpath are returned.
     :return: A Nexus results list with the Nexus payloads of the ACLs.
     """
     return http_get([SEGMENT, subpath], rev=rev, self=self)
@@ -26,8 +26,8 @@ def fetch_(path: str, rev: int = None, self: bool = True) -> Dict:
     :param path: Full path on which fetching the ACLs.
     :param rev: (optional) Revision number of the ACLs.
     :param self: (optional) If 'True', only the ACLs containing the identities
-    found in the authentication token are returned. If 'False', all the ACLs
-    on the current subpath are returned.
+        found in the authentication token are returned. If 'False', all the
+        ACLs on the current subpath are returned.
     :return: A Nexus results list with the Nexus payloads of the ACLs.
     """
     return http_get(path, rev=rev, self=self)
@@ -38,11 +38,11 @@ def list(subpath: str, ancestors: bool = False, self: bool = True) -> Dict:
 
     :param subpath: Subpath on which listing the ACLs.
     :param ancestors: (optional) If 'True', the ACLs on the parent path of the
-    subpath are returned. If 'False', only the ACLs on the current subpath are
-    returned.
+        subpath are returned. If 'False', only the ACLs on the current subpath
+        are returned.
     :param self: (optional) If 'True', only the ACLs containing the identities
-    found in the authentication token are returned. If 'False', all the ACLs
-    on the current subpath are returned.
+        found in the authentication token are returned. If 'False', all the
+        ACLs on the current subpath are returned.
     :return: A Nexus results list with the Nexus payloads of the ACLs.
     """
     return http_get([SEGMENT, subpath], ancestors=ancestors, self=self)
@@ -53,11 +53,11 @@ def list_(path: str, ancestors: bool = False, self: bool = True) -> Dict:
 
     :param path: Full path on which listing the ACLs.
     :param ancestors: (optional) If 'True', the ACLs on the parent path of the
-    subpath are returned. If 'False', only the ACLs on the current subpath are
-    returned.
+        subpath are returned. If 'False', only the ACLs on the current subpath
+        are returned.
     :param self: (optional) If 'True', only the ACLs containing the identities
-    found in the authentication token are returned. If 'False', all the ACLs
-    on the current subpath are returned.
+        found in the authentication token are returned. If 'False', all the
+        ACLs on the current subpath are returned.
     :return: A Nexus results list with the Nexus payloads of the ACLs.
     """
     return http_get(path, ancestors=ancestors, self=self)
@@ -65,16 +65,16 @@ def list_(path: str, ancestors: bool = False, self: bool = True) -> Dict:
 
 # Update functions.
 
-def replace(subpath: str, permissions: List[str], identity: Dict, rev: int) -> Dict:
-    """Replace ACLs on a subpath.
+def replace(subpath: str, permissions: List[List[str]], identities: List[Dict], rev: int) -> Dict:
+    """Replace ACLs on a subpath. ``permissions`` and ``identities`` have the same order.
 
     :param subpath: Subpath on which replacing the ACLs.
-    :param permissions: List of permissions.
-    :param identity: Payload of the identity for which to replace permissions.
+    :param permissions: List of list of permissions.
+    :param identities: List of identities for which to replace permissions.
     :param rev: Last revision of the ACLs.
     :return: The Nexus metadata of the ACLs.
     """
-    payload = _payload(permissions, identity)
+    payload = _payload(permissions, identities)
     return http_put([SEGMENT, subpath], payload, rev=rev)
 
 
@@ -89,16 +89,16 @@ def replace_(path: str, payload: Dict, rev: int) -> Dict:
     return http_put(path, payload, rev=rev)
 
 
-def append(subpath: str, permissions: List[str], identity: Dict, rev: int) -> Dict:
-    """Append ACLs on a subpath.
+def append(subpath: str, permissions: List[List[str]], identities: List[Dict], rev: int) -> Dict:
+    """Append ACLs on a subpath. ``permissions`` and ``identities`` have the same order.
 
     :param subpath: Subpath on which appending ACLs.
-    :param permissions: List of permissions.
-    :param identity: Payload of the identity for which to append the permissions.
+    :param permissions: List of list of permissions.
+    :param identities: List of identities for which to append the permissions.
     :param rev: Last revision of the ACLs.
     :return: The Nexus metadata of the ACLs.
     """
-    payload = _payload(permissions, identity, "Append")
+    payload = _payload(permissions, identities, "Append")
     return http_patch([SEGMENT, subpath], payload, rev=rev)
 
 
@@ -113,16 +113,16 @@ def append_(path: str, payload: Dict, rev: int) -> Dict:
     return http_patch(path, payload, rev=rev)
 
 
-def subtract(subpath: str, permissions: List[str], identity: Dict, rev: int) -> Dict:
-    """Subtract ACLs on a subpath.
+def subtract(subpath: str, permissions: List[List[str]], identities: List[Dict], rev: int) -> Dict:
+    """Subtract ACLs on a subpath. ``permissions`` and ``identities`` have the same order.
 
     :param subpath: Subpath on which subtracting ACLs.
-    :param permissions: List of permissions.
-    :param identity: Payload of the identity for which to remove the permissions.
+    :param permissions: List of list of permissions.
+    :param identities: List of identities for which to remove the permissions.
     :param rev: Last revision of the ACLs.
     :return: The Nexus metadata of the ACLs.
     """
-    payload = _payload(permissions, identity, "Subtract")
+    payload = _payload(permissions, identities, "Subtract")
     return http_patch([SEGMENT, subpath], payload, rev=rev)
 
 
@@ -161,20 +161,20 @@ def delete_(path: str, rev: int) -> Dict:
 
 # Internal helpers
 
-def _payload(permissions: List[str], identity: Dict, operation: str = None) -> Dict:
-    """Create an ACLs payload.
+def _payload(permissions: List[List[str]], identities: List[Dict], operation: str = None) -> Dict:
+    """Create an ACLs payload. ``permissions`` and ``identities`` have the same order.
 
-    :param permissions: List of permissions.
-    :param identity: Payload of the identity to which the permissions apply.
+    :param permissions: List of list of permissions.
+    :param identities: List of identities to which the permissions apply.
     :param operation: (optional) Corresponding operation: 'Append' or 'Subtract'.
     :return: Payload of the ACLs.
     """
     payload = {
         "acl": [
             {
-                "permissions": permissions,
-                "identity": identity,
-            },
+                "permissions": x,
+                "identity": y,
+            } for x, y in zip(permissions, identities)
         ]
     }
     if operation is not None:

--- a/nexussdk/realms.py
+++ b/nexussdk/realms.py
@@ -7,16 +7,17 @@ SEGMENT = "realms"
 
 # Create functions.
 
-def create(name: str, description: str, openid_config: str) -> Dict:
+def create(subpath: str, name: str, openid_config: str, logo: str = None) -> Dict:
     """Create a realm.
 
+    :param subpath: Subpath of the realm.
     :param name: Name of the realm.
-    :param description: Description of the realm.
     :param openid_config: URL of the OpenID configuration.
+    :param logo: (optional) URL of a logo.
     :return: The Nexus metadata of the created realm.
     """
-    payload = _payload(description, openid_config)
-    return http_put([SEGMENT, name], payload)
+    payload = _payload(name, openid_config, logo)
+    return http_put([SEGMENT, subpath], payload)
 
 
 def create_(path: str, payload: Dict) -> Dict:
@@ -31,14 +32,14 @@ def create_(path: str, payload: Dict) -> Dict:
 
 # Read functions.
 
-def fetch(name: str, rev: int = None) -> Dict:
+def fetch(subpath: str, rev: int = None) -> Dict:
     """Fetch a realm.
 
-    :param name: Name of the realm.
+    :param subpath: Subpath of the realm.
     :param rev: (optional) Revision number of the realm.
     :return: The Nexus payload of the fetched realm.
     """
-    return http_get([SEGMENT, name], rev=rev)
+    return http_get([SEGMENT, subpath], rev=rev)
 
 
 def fetch_(path: str, rev: int = None) -> Dict:
@@ -70,40 +71,41 @@ def list_(endpoint: str) -> Dict:
 
 # Update functions.
 
-def update(name: str, description: str, openid_config: str, rev: int) -> Dict:
-    """Update a realm.
-    
+def replace(subpath: str, name: str, openid_config: str, rev: int, logo: str = None) -> Dict:
+    """Replace a realm.
+
+    :param subpath: Subpath of the realm.
     :param name: Name of the realm.
-    :param description: Updated description of the realm.
     :param openid_config: Updated URL of the OpenID configuration.
     :param rev: Last revision of the realm.
-    :return: The Nexus metadata of the updated realm.
+    :param logo: (optional) Updated URL of a logo.
+    :return: The Nexus metadata of the realm.
     """
-    payload = _payload(description, openid_config)
-    return http_put([SEGMENT, name], payload, rev=rev)
+    payload = _payload(name, openid_config, logo)
+    return http_put([SEGMENT, subpath], payload, rev=rev)
 
 
-def update_(path: str, payload: Dict, rev: int) -> Dict:
-    """Update a realm (full path version).
+def replace_(path: str, payload: Dict, rev: int) -> Dict:
+    """Replace a realm (full path version).
     
     :param path: Full path of the realm.
     :param payload: Updated payload of the realm.
     :param rev: Last revision of the realm.
-    :return: The Nexus metadata of the updated realm.
+    :return: The Nexus metadata of the realm.
     """
     return http_put(path, payload, rev=rev)
 
 
 # Delete functions.
 
-def deprecate(name: str, rev: int) -> Dict:
+def deprecate(subpath: str, rev: int) -> Dict:
     """Deprecate a realm.
     
-    :param name: Name of the realm.
+    :param subpath: Subpath of the realm.
     :param rev: Last revision of the realm.
     :return: The Nexus metadata of the deprecated realm.
     """
-    return http_delete([SEGMENT, name], rev=rev)
+    return http_delete([SEGMENT, subpath], rev=rev)
 
 
 def deprecate_(path: str, rev: int) -> Dict:
@@ -118,14 +120,18 @@ def deprecate_(path: str, rev: int) -> Dict:
 
 # Internal helpers
 
-def _payload(description: str, openid_config: str) -> Dict:
+def _payload(name: str, openid_config: str, logo: str = None) -> Dict:
     """Create a realm payload.
     
-    :param description: Description of the realm.
+    :param name: Name of the realm.
     :param openid_config: URL of the OpenID configuration.
+    :param logo: (optional) URL of a logo.
     :return: Payload of the realm.
     """
-    return {
-        "name": description,
+    payload = {
+        "name": name,
         "openIdConfig": openid_config,
     }
+    if logo is not None:
+        payload["logo"] = logo
+    return payload

--- a/notebooks/IAM - ACLs.ipynb
+++ b/notebooks/IAM - ACLs.ipynb
@@ -57,10 +57,44 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IDENTITY = {\n",
+    "    \"realm\": \"myrealm\",\n",
+    "    \"subject\": \"mysubject\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IDENTITY_BIS = {\n",
+    "    \"realm\": \"myrealm2\",\n",
+    "    \"subject\": \"mysubject2\",\n",
+    "}"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### User API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdm = randint(0,1000)\n",
+    "rdm"
    ]
   },
   {
@@ -71,7 +105,7 @@
    },
    "outputs": [],
    "source": [
-    "subpath = \"myorg\""
+    "subpath = \"myorg{}\".format(rdm)"
    ]
   },
   {
@@ -93,10 +127,16 @@
    },
    "outputs": [],
    "source": [
-    "identity = {\n",
-    "    \"realm\": \"myrealm\",\n",
-    "    \"subject\": \"mysubject\",\n",
-    "}"
+    "identity = IDENTITY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identity2 = IDENTITY_BIS"
    ]
   },
   {
@@ -105,6 +145,15 @@
    "metadata": {
     "scrolled": true
    },
+   "outputs": [],
+   "source": [
+    "identities = [identity, identity2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -218,8 +267,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To be able to run the notebook multiple times.\n",
-    "latest_rev = 0"
+    "pp(nxs.acls.replace(subpath, [[\"projects/read\"]], [identity], rev=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch(subpath, self=False))"
    ]
   },
   {
@@ -230,15 +289,34 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    pp(nxs.acls.replace(subpath, [\"projects/read\"], identity, rev=latest_rev))\n",
-    "except nxs.HTTPError as e:\n",
-    "    nexus_error = e.response.json()\n",
-    "    if nexus_error[\"@type\"] == \"IncorrectRev\":\n",
-    "        latest_rev = nexus_error[\"expected\"]\n",
-    "        pp(nxs.acls.replace(subpath, [\"projects/read\"], identity, rev=latest_rev))\n",
-    "    else:\n",
-    "        raise e"
+    "pp(nxs.acls.replace(subpath, [[\"projects/read\"], [\"resources/read\"]], identities, rev=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch(subpath, self=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.append(subpath, [[\"projects/write\"]], [identity], rev=2))"
    ]
   },
   {
@@ -247,6 +325,24 @@
    "metadata": {
     "scrolled": false
    },
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch(subpath, self=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.append(subpath, [[\"projects/create\"], [\"resources/write\"]], identities, rev=3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "pp(nxs.acls.fetch(subpath, self=False))"
@@ -269,7 +365,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.append(subpath, [\"projects/write\"], identity, rev=latest_rev+1))"
+    "pp(nxs.acls.subtract(subpath, [[\"projects/read\"]], [identity], rev=4))"
    ]
   },
   {
@@ -286,21 +382,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "pp(nxs.acls.subtract(subpath, [\"projects/read\"], identity, rev=latest_rev+2))"
+    "pp(nxs.acls.subtract(subpath, [[\"projects/create\"], [\"resources/read\"]], identities, rev=5))"
    ]
   },
   {
@@ -317,9 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -331,7 +414,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.delete(subpath, rev=latest_rev+3))"
+    "pp(nxs.acls.delete(subpath, rev=6))"
    ]
   },
   {
@@ -397,12 +480,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdm2 = randint(0, 1000)\n",
+    "rdm2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subpath2 = \"myorg{}\".format(rdm2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "path = \"{}/{}\".format(endpoint, subpath)\n",
+    "path = \"{}/{}\".format(endpoint, subpath2)\n",
     "path"
    ]
   },
@@ -441,10 +543,7 @@
     "            \"permissions\": [\n",
     "                \"projects/read\",\n",
     "            ],\n",
-    "            \"identity\": {\n",
-    "                \"realm\": \"myrealm\",\n",
-    "                \"subject\": \"mysubject\",\n",
-    "            }\n",
+    "            \"identity\": IDENTITY\n",
     "        },\n",
     "    ]\n",
     "}"
@@ -479,9 +578,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acls_list = {\n",
+    "    \"acl\": [\n",
+    "        {\n",
+    "            \"permissions\": [\n",
+    "                \"projects/read\",\n",
+    "            ],\n",
+    "            \"identity\": IDENTITY\n",
+    "        },\n",
+    "        {\n",
+    "            \"permissions\": [\n",
+    "                \"resources/read\",\n",
+    "            ],\n",
+    "            \"identity\": IDENTITY_BIS\n",
+    "        },\n",
+    "    ]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
+   "outputs": [],
+   "source": [
+    "append_acls_list = copy.deepcopy(acls_list)\n",
+    "append_acls_list[\"@type\"] = \"Append\"\n",
+    "append_acls_list[\"acl\"][0][\"permissions\"] = [\"projects/create\"]\n",
+    "append_acls_list[\"acl\"][1][\"permissions\"] = [\"resources/write\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "subtract_acls_list = copy.deepcopy(acls_list)\n",
+    "subtract_acls_list[\"@type\"] = \"Subtract\"\n",
+    "subtract_acls_list[\"acl\"][0][\"permissions\"] = [\"projects/create\"]\n",
+    "subtract_acls_list[\"acl\"][1][\"permissions\"] = [\"resources/read\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -610,7 +759,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.replace_(path, acls, rev=latest_rev+4))"
+    "pp(nxs.acls.replace_(path, acls, rev=0))"
    ]
   },
   {
@@ -623,6 +772,40 @@
    "source": [
     "pp(nxs.acls.fetch_(path, self=False))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(acls_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.replace_(path, acls_list, rev=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch_(path, self=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -652,7 +835,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.append_(path, append_acls, rev=latest_rev+5))"
+    "pp(nxs.acls.append_(path, append_acls, rev=2))"
    ]
   },
   {
@@ -669,9 +852,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(append_acls_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.append_(path, append_acls_list, rev=3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch_(path, self=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -694,7 +904,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.subtract_(path, subtract_acls, rev=latest_rev+6))"
+    "pp(nxs.acls.subtract_(path, subtract_acls, rev=4))"
    ]
   },
   {
@@ -703,6 +913,33 @@
    "metadata": {
     "scrolled": false
    },
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.fetch_(path, self=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(subtract_acls_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp(nxs.acls.subtract_(path, subtract_acls_list, rev=5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "pp(nxs.acls.fetch_(path, self=False))"
@@ -725,7 +962,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.acls.delete_(path, rev=latest_rev+7))"
+    "pp(nxs.acls.delete_(path, rev=6))"
    ]
   },
   {

--- a/notebooks/IAM - Realms.ipynb
+++ b/notebooks/IAM - Realms.ipynb
@@ -62,6 +62,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "LOGO = \"http://nexus.example.com/logo.png\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import json\n",
     "def pp(x): print(json.dumps(x, indent=2))"
    ]
@@ -81,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "rdm = randint(0,1000)\n",
+    "rdm = randint(0, 1000)\n",
     "rdm"
    ]
   },
@@ -93,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "realm = \"myrealm{}\".format(rdm)"
+    "subpath = \"myrealm{}\".format(rdm)"
    ]
   },
   {
@@ -104,7 +113,7 @@
    },
    "outputs": [],
    "source": [
-    "description = \"Test realm {}\".format(rdm)"
+    "name = \"Test realm {}\".format(rdm)"
    ]
   },
   {
@@ -126,7 +135,7 @@
    },
    "outputs": [],
    "source": [
-    "updated_description = \"{} (updated)\".format(description)"
+    "updated_name = \"{} (updated)\".format(name)"
    ]
   },
   {
@@ -136,7 +145,9 @@
     "scrolled": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "logo = LOGO"
+   ]
   },
   {
    "cell_type": "code",
@@ -146,7 +157,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.create(realm, description, openid_config))"
+    "pp(nxs.realms.create(subpath, name, openid_config, logo))"
    ]
   },
   {
@@ -166,7 +177,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch(realm))"
+    "pp(nxs.realms.fetch(subpath))"
    ]
   },
   {
@@ -178,7 +189,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    pp(nxs.realms.fetch(realm, rev=2))\n",
+    "    pp(nxs.realms.fetch(subpath, rev=2))\n",
     "except nxs.HTTPError as e:\n",
     "    print(e)\n",
     "    print(\"---\")\n",
@@ -222,7 +233,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.update(realm, updated_description, openid_config, rev=1))"
+    "pp(nxs.realms.replace(subpath, updated_name, openid_config, rev=1))"
    ]
   },
   {
@@ -233,7 +244,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch(realm))"
+    "pp(nxs.realms.fetch(subpath))"
    ]
   },
   {
@@ -253,7 +264,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.deprecate(realm, rev=2))"
+    "pp(nxs.realms.deprecate(subpath, rev=2))"
    ]
   },
   {
@@ -264,7 +275,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch(realm))"
+    "pp(nxs.realms.fetch(subpath))"
    ]
   },
   {
@@ -324,7 +335,7 @@
    },
    "outputs": [],
    "source": [
-    "rdm2 = randint(0,1000)\n",
+    "rdm2 = randint(0, 1000)\n",
     "rdm2"
    ]
   },
@@ -336,7 +347,7 @@
    },
    "outputs": [],
    "source": [
-    "realm2 = \"myrealm{}\".format(rdm2)"
+    "subpath2 = \"myrealm{}\".format(rdm2)"
    ]
   },
   {
@@ -347,8 +358,8 @@
    },
    "outputs": [],
    "source": [
-    "realm_path = \"{}/{}\".format(endpoint, realm2)\n",
-    "realm_path"
+    "path = \"{}/{}\".format(endpoint, subpath2)\n",
+    "path"
    ]
   },
   {
@@ -368,9 +379,10 @@
    },
    "outputs": [],
    "source": [
-    "base_payload = {\n",
+    "config = {\n",
     "    \"name\": \"Test realm {}\".format(rdm2),\n",
     "    \"openIdConfig\": OPENID_CONFIG,\n",
+    "    \"logo\": LOGO\n",
     "}"
    ]
   },
@@ -382,8 +394,9 @@
    },
    "outputs": [],
    "source": [
-    "update_payload = copy.deepcopy(base_payload)\n",
-    "update_payload[\"name\"] += \" (updated)\""
+    "update_config = copy.deepcopy(config)\n",
+    "update_config[\"name\"] += \" (updated)\"\n",
+    "del update_config[\"logo\"]"
    ]
   },
   {
@@ -403,7 +416,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(base_payload)"
+    "pp(config)"
    ]
   },
   {
@@ -414,7 +427,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.create_(realm_path, base_payload))"
+    "pp(nxs.realms.create_(path, config))"
    ]
   },
   {
@@ -434,7 +447,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch_(realm_path))"
+    "pp(nxs.realms.fetch_(path))"
    ]
   },
   {
@@ -446,7 +459,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    pp(nxs.realms.fetch_(realm_path, rev=2))\n",
+    "    pp(nxs.realms.fetch_(path, rev=2))\n",
     "except nxs.HTTPError as e:\n",
     "    print(e)\n",
     "    print(\"---\")\n",
@@ -490,7 +503,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(update_payload)"
+    "pp(update_config)"
    ]
   },
   {
@@ -501,7 +514,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.update_(realm_path, update_payload, rev=1))"
+    "pp(nxs.realms.replace_(path, update_config, rev=1))"
    ]
   },
   {
@@ -512,7 +525,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch_(realm_path))"
+    "pp(nxs.realms.fetch_(path))"
    ]
   },
   {
@@ -532,7 +545,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.deprecate_(realm_path, rev=2))"
+    "pp(nxs.realms.deprecate_(path, rev=2))"
    ]
   },
   {
@@ -543,7 +556,7 @@
    },
    "outputs": [],
    "source": [
-    "pp(nxs.realms.fetch_(realm_path))"
+    "pp(nxs.realms.fetch_(path))"
    ]
   },
   {


### PR DESCRIPTION
Changes in bold.

## Realms

create(name: str, **description**: str, openid_config: str) -> Dict
is now
create(**subpath**: str, name: str, openid_config: str, **logo**: str = None) -> Dict

fetch(**name**: str, rev: int = None) -> Dict
is now
fetch(**subpath**: str, rev: int = None) -> Dict

**update**(name: str, **description**: str, openid_config: str, rev: int) -> Dict
is now
**replace**(**subpath**: str, name: str, openid_config: str, rev: int, **logo**: str = None) -> Dict

**update_**(path: str, payload: Dict, rev: int) -> Dict
is now
**replace_**(path: str, payload: Dict, rev: int) -> Dict

deprecate(**name**: str, rev: int) -> Dict
is now
deprecate(**subpath**: str, rev: int) -> Dict

Corresponding notebook adapted. See usage examples there.


## ACLs

replace(subpath: str, permissions: List[str], **identity**: Dict, rev: int) -> Dict
is now
replace(subpath: str, permissions: **List**[List[str]], **identities**: **List**[Dict], rev: int) -> Dict

append(subpath: str, permissions: List[str], **identity**: Dict, rev: int) -> Dict
is now
append(subpath: str, permissions: **List**[List[str]], **identities**: **List**[Dict], rev: int) -> Dict

subtract(subpath: str, permissions: List[str], **identity**: Dict, rev: int) -> Dict
is now
subtract(subpath: str, permissions: **List**[List[str]], **identities**: **List**[Dict], rev: int) -> Dict

Corresponding notebook adapted. See usage examples there.